### PR TITLE
Don't prefix ssh: to the front of the username

### DIFF
--- a/tramp-term.el
+++ b/tramp-term.el
@@ -114,7 +114,7 @@ enable tramp integration in that terminal."
   "Send bash commands to set up tramp integration."
   (term-send-raw-string (format "
 function set-eterm-dir {
-    echo -e \"\\033AnSiTu\" \"ssh:$USER\"
+    echo -e \"\\033AnSiTu\" \"$USER\"
     echo -e \"\\033AnSiTc\" \"$PWD\"
     echo -e \"\\033AnSiTh\" \"%s\"
     history -a


### PR DESCRIPTION
As of emacs 25ish, the ssh: is no longer implied. When it's used, it ends up in $USER already, so we need to not insert it again here.

A better fix might be to look to see if USER starts with "ssh:" and add it if it's absent