### PR TITLE
Allow an optional (user host) argument to tramp-term

### DIFF
--- a/tramp-term.el
+++ b/tramp-term.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2014 Randy Morris
 
 ;; Author: Randy Morris <randy.morris@archlinux.us>
-;; Version: 0.4
+;; Version: 0.5
 ;; Keywords: tramp, ssh
 ;; URL: https://github.com/randymorris/tramp-term.el
 
@@ -47,11 +47,13 @@
   hostname used to connect to the remote machine.")
 
 ;;;###autoload
-(defun tramp-term ()
+(defun tramp-term (&optional host-arg)
   "Create an ansi-term running ssh session and automatically
-enable tramp integration in that terminal."
+enable tramp integration in that terminal.  Optional argument
+HOST-ARG is a list or one or two elements, the last of which is
+the host name."
   (interactive)
-  (let* ((host (tramp-term--select-host))
+  (let* ((host (or host-arg (tramp-term--select-host)))
          (hostname (car (last host)))
          (prompt-bound nil))
     (if (or (> (length host) 2)


### PR DESCRIPTION
Sometimes we want to create a terminal non-interactively.  For
example, we might define some convenience functions:

  (defun open-myhost ()
    (interactive)
    (tramp-term '("myhost.mydomain.com")))

  (defun open-myhost-as-user ()
    (interactive)
    (tramp-term '("user" "myhost.mydomain.com")))

Allow tramp-term to take an optional argument specifying the host.